### PR TITLE
Develop

### DIFF
--- a/FplBot.sln
+++ b/FplBot.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29926.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FplBot", "FplBot\FplBot.csproj", "{94B75EA6-234F-493A-BA95-0907EA2CA3A0}"
 EndProject
@@ -21,8 +21,8 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{94B75EA6-234F-493A-BA95-0907EA2CA3A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{94B75EA6-234F-493A-BA95-0907EA2CA3A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{94B75EA6-234F-493A-BA95-0907EA2CA3A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{94B75EA6-234F-493A-BA95-0907EA2CA3A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94B75EA6-234F-493A-BA95-0907EA2CA3A0}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{94B75EA6-234F-493A-BA95-0907EA2CA3A0}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FplBot/FplBot.cs
+++ b/FplBot/FplBot.cs
@@ -717,14 +717,13 @@ namespace FplBot
             var allPicks = this.fplPicks
                 .Where(team => team.Value.AutomaticSubs.Count() > 0)
                 .Select(team =>
-
-                new AutomaticSub()
-                {
-                    ElementInScore = team.Value.AutomaticSubs.Sum(sub => this.fplPlayerSummaries[sub.ElementIn.Value].History[this.currentEventId - 1].TotalPoints.Value),
-                    ElementInName = TextUtilities.NaturalParse(team.Value.AutomaticSubs.Select(sub => this.soccerPlayers[sub.ElementIn.Value].WebName)),
-                    ElementOutName = TextUtilities.NaturalParse(team.Value.AutomaticSubs.Select(sub => this.soccerPlayers[sub.ElementOut.Value].WebName)),
-                    TeamEntryId = team.Key,
-                })
+                    new AutomaticSub()
+                    {
+                        ElementInScore = team.Value.AutomaticSubs.Sum(sub => this.fplPlayerSummaries[sub.ElementIn.Value].History.Find(x => x.Round == this.currentEventId)?.TotalPoints.Value ?? 0),
+                        ElementInName = TextUtilities.NaturalParse(team.Value.AutomaticSubs.Select(sub => this.soccerPlayers[sub.ElementIn.Value].WebName)),
+                        ElementOutName = TextUtilities.NaturalParse(team.Value.AutomaticSubs.Select(sub => this.soccerPlayers[sub.ElementOut.Value].WebName)),
+                        TeamEntryId = team.Key,
+                    })
                 .OrderByDescending(x => x.ElementInScore);
             
             var groupedPicks = allPicks

--- a/FplBot/FplBot.cs
+++ b/FplBot/FplBot.cs
@@ -379,7 +379,7 @@ namespace FplBot
                 result.Append("The ");
             }
 
-            result.Append($"winner{TextUtilities.Pluralize(winnerNames.Count())} for gameweek #{this.currentEventId} {TextUtilities.WasWere(winnerNames.Count())} {TextUtilities.NaturalParse(winnerNames)} with {topScore} points");
+            result.Append($"winner{TextUtilities.Pluralize(winnerNames.Count())} for {this.currentEvent.Name.ToLowerInvariant()} {TextUtilities.WasWere(winnerNames.Count())} {TextUtilities.NaturalParse(winnerNames)} with {topScore} points");
 
             if (winnerHitCost > 0 && winnerNames.Count() == 1)
             {
@@ -502,45 +502,48 @@ namespace FplBot
                 .GroupBy(c => c.EventScoreMultiplied)
                 .OrderByDescending(g => g.Key);
 
-            int noBest = groupedScores.First().Count();
-            int noWorst = groupedScores.Last().Count();
-            long bestScore = groupedScores.First().Key;
-            long worstScore = groupedScores.Last().Key;
+            int noBest = groupedScores.FirstOrDefault()?.Count() ?? 0;
+            int noWorst = groupedScores.LastOrDefault()?.Count() ?? 0;
+            long bestScore = groupedScores.FirstOrDefault()?.Key ?? 0;
+            long worstScore = groupedScores.LastOrDefault()?.Key ?? 0;
 
             List<long> bestPlayerIds = new List<long>();
             List<long> worstPlayerIds = new List<long>();
             List<long> bestTeamIds = new List<long>();
             List<long> worstTeamIds = new List<long>();
 
-            foreach (var p in groupedScores.First())
+            if (groupedScores.Count() > 0)
             {
-                if (!bestPlayerIds.Contains(p.ActivePlayerId))
+                foreach (var p in groupedScores.First())
                 {
-                    bestPlayerIds.Add(p.ActivePlayerId);
+                    if (!bestPlayerIds.Contains(p.ActivePlayerId))
+                    {
+                        bestPlayerIds.Add(p.ActivePlayerId);
+                    }
+
+                    if (!bestTeamIds.Contains(p.TeamEntryId))
+                    {
+                        bestTeamIds.Add(p.TeamEntryId);
+                    }
                 }
 
-                if (!bestTeamIds.Contains(p.TeamEntryId))
+                foreach (var p in groupedScores.Last())
                 {
-                    bestTeamIds.Add(p.TeamEntryId);
+                    if (!worstPlayerIds.Contains(p.ActivePlayerId))
+                    {
+                        worstPlayerIds.Add(p.ActivePlayerId);
+                    }
+
+                    if (!worstTeamIds.Contains(p.TeamEntryId))
+                    {
+                        worstTeamIds.Add(p.TeamEntryId);
+                    }
                 }
+
+                result.Append($"When it came to captaincy choice{TextUtilities.Pluralize(noBest)} {TextUtilities.NaturalParse(bestTeamIds.Select(i => $"{this.fplTeams[i].Name}").ToList())} did the best this week with {bestScore} point{TextUtilities.Pluralize(noBest)} from {TextUtilities.NaturalParse(bestPlayerIds.Select(i => $"{this.soccerPlayers[i].FirstName} {this.soccerPlayers[i].SecondName}").ToList())}. ");
+                result.AppendLine($"On the other end of the spectrum were {TextUtilities.NaturalParse(worstTeamIds.Select(i => $"{this.fplTeams[i].Name}").ToList())} who had picked {TextUtilities.NaturalParse(worstPlayerIds.Select(i => $"{this.soccerPlayers[i].FirstName} {this.soccerPlayers[i].SecondName}").ToList())} for a total of {worstScore} point{TextUtilities.Pluralize((int)worstScore)}. You receive the armband of shame for this week. ");
             }
-
-            foreach (var p in groupedScores.Last())
-            {
-                if (!worstPlayerIds.Contains(p.ActivePlayerId))
-                {
-                    worstPlayerIds.Add(p.ActivePlayerId);
-                }
-
-                if (!worstTeamIds.Contains(p.TeamEntryId))
-                {
-                    worstTeamIds.Add(p.TeamEntryId);
-                }
-            }
-
-            result.Append($"When it came to captaincy choice{TextUtilities.Pluralize(noBest)} {TextUtilities.NaturalParse(bestTeamIds.Select(i => $"{this.fplTeams[i].Name}").ToList())} did the best this week with {bestScore} point{TextUtilities.Pluralize(noBest)} from {TextUtilities.NaturalParse(bestPlayerIds.Select(i => $"{this.soccerPlayers[i].FirstName} {this.soccerPlayers[i].SecondName}").ToList())}. ");
-            result.AppendLine($"On the other end of the spectrum were {TextUtilities.NaturalParse(worstTeamIds.Select(i => $"{this.fplTeams[i].Name}").ToList())} who had picked {TextUtilities.NaturalParse(worstPlayerIds.Select(i => $"{this.soccerPlayers[i].FirstName} {this.soccerPlayers[i].SecondName}").ToList())} for a total of {worstScore} point{TextUtilities.Pluralize((int)worstScore)}. You receive the armband of shame for this week. ");
-
+            
             return result.ToString();
         }
 
@@ -730,15 +733,15 @@ namespace FplBot
                 .GroupBy(x => x.ElementInScore)
                 .OrderByDescending(x => x.Key);
 
-            var best = groupedPicks.First();
-            var worst = groupedPicks.Last();
-
             if (allPicks.Count() < 1)
             {
-                result.AppendLine("No teams had automatic substitutions made this week.");
+                result.Append("No teams had automatic substitutions made this week. ");
             }
             else
             {
+                var best = groupedPicks.First();
+                var worst = groupedPicks.Last();
+
                 if (best.Count() > 1)
                 {
                     result.Append($"Managers from {TextUtilities.NaturalParse(best.Select(i => $"{this.fplTeams[i.TeamEntryId].Name}").ToList())} did the best with automatic substitutions this week receiving");
@@ -889,7 +892,7 @@ namespace FplBot
             const int dashPadding = 49;
             int longestTeamName = this.currentWeekStandings.Max(x => x.Value.Name.Length);
 
-            standings.AppendLine($"Standings for {this.fplLeague.League.Name} after GW#{this.currentEventId}:");
+            standings.AppendLine($"Standings for {this.fplLeague.League.Name} after {this.currentEvent.Name}:");
             standings.AppendLine("".PadLeft(longestTeamName + dashPadding, '-'));
             standings.AppendLine($"Rank Chg. PW   Overall  Team{string.Empty.PadLeft(longestTeamName - 4)}   GW  Total   TT   TmVal");
             standings.AppendLine("".PadLeft(longestTeamName + dashPadding, '-')).AppendLine();
@@ -967,7 +970,7 @@ namespace FplBot
                         Content = new MimeContent(stream, ContentEncoding.Default),
                         ContentDisposition = new ContentDisposition(ContentDisposition.Attachment),
                         ContentTransferEncoding = ContentEncoding.Base64,
-                        FileName = Path.GetFileName($"Standings-GW{this.currentEventId.ToString()}.txt")
+                        FileName = Path.GetFileName($"Standings-{this.currentEvent.Name.Replace(" ", "")}.txt")
                     };
 
                     multipart.Add(attachment);

--- a/FplBot/Properties/AssemblyInfo.cs
+++ b/FplBot/Properties/AssemblyInfo.cs
@@ -10,4 +10,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
 [assembly: Guid("94b75ea6-234f-493a-ba95-0907ea2ca3a0")]
-[assembly: AssemblyVersion("2.1.*")]
+[assembly: AssemblyVersion("2.2.*")]


### PR DESCRIPTION
Fix crash for weird autosub issue
Fix crashes that'll happen during empty gameweeks (30-38)
Switch from using index to denote gameweek name to using the actual gameweek name (the two will diverge after GW38)